### PR TITLE
Scaling up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ The Directory-sync library is designed to synchronize between a FHIR store assoc
 
 This is meant to make the lives of biobank administrators a little easier, since they must currently perform this synchronization by hand.
 
-At the time of writing (10.12.2021), only the sample counts per collection are sent to the Directory. Only Biobank name and responsible people are retrieved from the Directory. In order to make this library really useful to biobank administrators, it would be good if lists of ICD 10 codes used in the collections could also be pushed to the Directory, but this functionality does not yet exist.
+The library can update the Direcory with the following information, on a per-collection basis:
+- number of donors/patients
+- number of samples
+- sex
+- diagnosis
+- age range
+- sample types
+- storage temperatures
+
+It is also possible to send data in the star model format. This aggregates the data into hypercubes.
+
+Data relating to biobank contact details can be retrieved from the Directory and stored in the FHIR store.
+
+The Sync class is the main entrypoint into this library. See the Javadoc in Sync.java for more details.
 
 The library was written to be used from within the (Connector)[https://github.com/samply/share-client]. However, it could be used from within any component that needs Directory-sync functionality.
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <hapi.version>5.7.2</hapi.version>
+        <!-- <hapi.version>6.10.2</hapi.version> -->
         <jackson.version>2.13.3</jackson.version>
         <mockito-core.version>4.5.1</mockito-core.version>
         <testcontainers.version>1.17.1</testcontainers.version>

--- a/src/main/java/de/samply/directory_sync/FhirCollectionToDirectoryCollectionPutConverter.java
+++ b/src/main/java/de/samply/directory_sync/FhirCollectionToDirectoryCollectionPutConverter.java
@@ -42,7 +42,8 @@ public class FhirCollectionToDirectoryCollectionPutConverter {
       convertAgeHigh(directoryCollectionPut, fhirCollection);
       convertMaterials(directoryCollectionPut, fhirCollection);
       convertStorageTemperatures(directoryCollectionPut, fhirCollection);
-      convertDiagnosisAvailableEmpty(directoryCollectionPut, fhirCollection);
+      // convertDiagnosisAvailableEmpty(directoryCollectionPut, fhirCollection);
+      convertDiagnosisAvailable(directoryCollectionPut, fhirCollection);
     } catch(Exception e) {
         logger.error("Problem converting FHIR attributes to Directory attributes. " + Util.traceFromException(e));
         return null;

--- a/src/main/java/de/samply/directory_sync/FhirToDirectoryAttributeConverter.java
+++ b/src/main/java/de/samply/directory_sync/FhirToDirectoryAttributeConverter.java
@@ -62,6 +62,7 @@ public class FhirToDirectoryAttributeConverter {
                 .replaceAll("^CSF_LIQUOR$", "OTHER")
                 .replaceAll("^LIQUID$", "OTHER")
                 .replaceAll("^ASCITES$", "OTHER")
+                .replaceAll("^BONE_MARROW$", "OTHER")
                 .replaceAll("^TISSUE_PAXGENE_OR_ELSE$", "OTHER")
                 ;
     

--- a/src/main/java/de/samply/directory_sync/StarModelData.java
+++ b/src/main/java/de/samply/directory_sync/StarModelData.java
@@ -44,47 +44,6 @@ public class StarModelData {
         this.minDonors = minDonors;
     }
 
-    // Maps diagnosis ICD 10 codes from the FHIR store onto acceptable
-    // values for the Directory.
-    private Map<String,String> diagnoses = new HashMap<String,String>();
-
-    /**
-     * Notes a diagnosis in the internal diagnoses map.
-     * 
-     * @param diagnosis The diagnosis to be noted in the diagnoses map.
-     * 
-     * @throws NullPointerException if diagnosis is null.
-     */
-    private void noteDiagnosis(String diagnosis) {
-        diagnoses.put(diagnosis, diagnosis);
-    }
-
-    /**
-     * Notes a corrected diagnosis associated for an existing diagnosis in the diagnoses map.
-     * If the original diagnosis is present in the map, it is replaced with the new diagnosis.
-     * If the original diagnosis is not present, a new entry is added to the map.
-     * 
-     * @param diagnosis The original diagnosis to be replaced or noted.
-     * @param newDiagnosis The corrected diagnosis to associate with the original diagnosis.
-     * 
-     * @throws NullPointerException if diagnosis or newDiagnosis is null.
-     */
-    public void noteDiagnosis(String diagnosis, String newDiagnosis) {
-        diagnoses.put(diagnosis, newDiagnosis);
-    }
-
-    /**
-     * Retrieves the diagnoses map containing the mapping of diagnoses to corrected diagnoses.
-     * 
-     * @return Diagnosis map.
-     * 
-     * @see #noteDiagnosis(String)
-     * @see #noteDiagnosis(String, String)
-     */    
-    public Map<String, String> getDiagnoses() {
-        return diagnoses;
-    }
-
     public List<Map<String, String>> getInputRowsAsStringMaps(String collectionId) {
         List<Map<String, String>> rowsAsStringMaps = new ArrayList<Map<String, String>>();
         for (InputRow row: inputData.get(collectionId)) {
@@ -262,7 +221,6 @@ public class StarModelData {
      * @throws NullPointerException if row or histLoc is null.
      */
     public InputRow newInputRow(InputRow row, String histLoc) {
-        noteDiagnosis(FhirToDirectoryAttributeConverter.convertDiagnosis(histLoc));
         return new InputRow(row, histLoc);
     }
 
@@ -314,9 +272,10 @@ public class StarModelData {
      * 
      * Note: This method directly modifies the factTables in-place.
      * 
+     * @param diagnoses Maps FHIR diagnoses onto Directory diagnoses.
      * @throws NullPointerException if diagnoses or any fact in factTables is null.
      */
-    public void implementDiagnosisCorrections() {
+    public void applyDiagnosisCorrections(Map<String,String> diagnoses) {
          for (Map<String, String> fact: factTables) {
             if (!fact.containsKey("disease"))
                 continue;

--- a/src/main/java/de/samply/directory_sync/directory/DirectoryApi.java
+++ b/src/main/java/de/samply/directory_sync/directory/DirectoryApi.java
@@ -203,7 +203,7 @@ public class DirectoryApi {
   /**
    * Make a call to the Directory to get all Collection IDs for the supplied {@code countryCode}.
    *
-   * @param countryCode the country code of the endpoint of the national node, e.g. Germany
+   * @param countryCode the country code of the endpoint of the national node, e.g. DE
    * @return all the Collections for the national node. E.g. "DE" will return all German collections
    */
   public Either<OperationOutcome, Set<BbmriEricId>> listAllCollectionIds(String countryCode) {
@@ -231,12 +231,12 @@ public class DirectoryApi {
   }
 
   /**
-   * Make API calls to the Directory to get a DirectoryCollectionGet object containing attributes
+   * Make API calls to the Directory to fill a DirectoryCollectionGet object containing attributes
    * for all of the collections listed in collectionIds. The countryCode is used solely for
    * constructing the URL for the API call.
    * 
-   * @param countryCode
-   * @param collectionIds
+   * @param countryCode E.g. "DE".
+   * @param collectionIds IDs of the collections whose data will be harvested.
    * @return
    */
   public Either<OperationOutcome, DirectoryCollectionGet> fetchCollectionGetOutcomes(String countryCode, List<String> collectionIds) {
@@ -281,13 +281,9 @@ public class DirectoryApi {
   }
 
   /**
-   * Send the collection entities to the Directory.
-   * <p>
-   * You need 'update data' permission on entity type
-   * 'Collections' at the Directory in order for this to work.
+   * Send aggregated collection information to the Directory.
    *
-   * @param countryCode
-   * @param entities    the individual entities.
+   * @param directoryCollectionPut Summary information about one or more collections
    * @return an outcome, either successful or an error
    */
   public OperationOutcome updateEntities(DirectoryCollectionPut directoryCollectionPut) {
@@ -516,8 +512,7 @@ public class DirectoryApi {
   }
   
   /**
-   * Collects diagnosis corrections for the StarModelInputData. These are
-   * stored in the diagnoses map.
+   * Collects diagnosis corrections from the Directory.
    * 
    * It checks with the Directory if the diagnosis codes are valid ICD values and corrects them if necessary.
    * 
@@ -526,11 +521,9 @@ public class DirectoryApi {
    * 1. If the full code is not correct, remove the number after the period and try again. If the new truncated code is OK, use it to replace the existing diagnosis.
    * 2. If that doesn't work, replace the existing diagnosis with null.
    *
-   * @param starModelInputData The input data containing diagnoses to be corrected.
-   * @return An OperationOutcome indicating the success or failure of the diagnosis corrections.
+   * @param diagnoses A string map containing diagnoses to be corrected.
    */
-  public OperationOutcome collectStarModelDiagnosisCorrections(StarModelData starModelInputData) {
-    Map<String, String> diagnoses = starModelInputData.getDiagnoses();
+  public void collectDiagnosisCorrections(Map<String, String> diagnoses) {
     for (String diagnosis: diagnoses.keySet())
       if (!isValidIcdValue(diagnosis)) {
         String diagnosisCategory = diagnosis.split("\\.")[0];
@@ -539,8 +532,6 @@ public class DirectoryApi {
         else
           diagnoses.put(diagnosis, null);
       }
-      
-    return null;
   }
 
   /**

--- a/src/main/java/de/samply/directory_sync/directory/DirectoryService.java
+++ b/src/main/java/de/samply/directory_sync/directory/DirectoryService.java
@@ -68,9 +68,4 @@ public class DirectoryService {
     OperationOutcome operationOutcome = api.updateStarModel(starModelInputData);
     return Collections.singletonList(operationOutcome);
   }
-
-  public OperationOutcome collectStarModelDiagnosisCorrections(StarModelData starModelInputData) {
-    OperationOutcome operationOutcome = api.collectStarModelDiagnosisCorrections(starModelInputData);
-    return operationOutcome;
-  }
 }

--- a/src/main/java/de/samply/directory_sync/directory/DirectoryService.java
+++ b/src/main/java/de/samply/directory_sync/directory/DirectoryService.java
@@ -18,10 +18,14 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 
 public class DirectoryService {
 
-  private final DirectoryApi api;
+  private DirectoryApi api;
 
   public DirectoryService(DirectoryApi api) {
     this.api = Objects.requireNonNull(api);
+  }
+
+  public void setApi(DirectoryApi api) {
+    this.api = api;
   }
 
   public List<OperationOutcome> updateCollectionSizes(Map<BbmriEricId, Integer> collectionSizes) {

--- a/src/main/java/de/samply/directory_sync/directory/model/DirectoryCollectionPut.java
+++ b/src/main/java/de/samply/directory_sync/directory/model/DirectoryCollectionPut.java
@@ -3,6 +3,7 @@ package de.samply.directory_sync.directory.model;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -24,79 +25,80 @@ public class DirectoryCollectionPut extends HashMap {
   private static final Logger logger = LoggerFactory.getLogger(DirectoryCollectionPut.class);
 
   public DirectoryCollectionPut() {
+        // Initializes the list of entities.
         this.put("entities", new ArrayList<Entity>());
     }
 
-    public void setCountry(String id, String country) {
-        getEntity(id).setCountry(country);
+    public void setCountry(String collectionId, String country) {
+        getEntity(collectionId).setCountry(country);
     }
 
-    public void setName(String id, String name) {
-        getEntity(id).setName(name);
+    public void setName(String collectionId, String name) {
+        getEntity(collectionId).setName(name);
     }
 
-    public void setDescription(String id, String description) {
-        getEntity(id).setDescription(description);
+    public void setDescription(String collectionId, String description) {
+        getEntity(collectionId).setDescription(description);
     }
 
-    public void setContact(String id, String contact) {
-        getEntity(id).setContact(contact);
+    public void setContact(String collectionId, String contact) {
+        getEntity(collectionId).setContact(contact);
     }
 
-    public void setBiobank(String id, String biobank) {
-        getEntity(id).setBiobank(biobank);
+    public void setBiobank(String collectionId, String biobank) {
+        getEntity(collectionId).setBiobank(biobank);
     }
 
-    public void setSize(String id, Integer size) {
-        getEntity(id).setSize(size);
+    public void setSize(String collectionId, Integer size) {
+        getEntity(collectionId).setSize(size);
     }
 
-    public void setOrderOfMagnitude(String id, Integer size) {
-        getEntity(id).setOrderOfMagnitude(size);
+    public void setOrderOfMagnitude(String collectionId, Integer size) {
+        getEntity(collectionId).setOrderOfMagnitude(size);
     }
 
-    public void setNumberOfDonors(String id, Integer size) {
-        getEntity(id).setNumberOfDonors(size);
+    public void setNumberOfDonors(String collectionId, Integer size) {
+        getEntity(collectionId).setNumberOfDonors(size);
     }
 
-    public void setOrderOfMagnitudeDonors(String id, Integer size) {
-        getEntity(id).setOrderOfMagnitudeDonors(size);
+    public void setOrderOfMagnitudeDonors(String collectionId, Integer size) {
+        getEntity(collectionId).setOrderOfMagnitudeDonors(size);
     }
 
-    public void setType(String id, List<String> type) {
-        getEntity(id).setType(type);
+    public void setType(String collectionId, List<String> type) {
+        getEntity(collectionId).setType(type);
     }
 
-    public void setDataCategories(String id, List<String> dataCategories) {
-        getEntity(id).setDataCategories(dataCategories);
+    public void setDataCategories(String collectionId, List<String> dataCategories) {
+        getEntity(collectionId).setDataCategories(dataCategories);
     }
 
-    public void setNetworks(String id, List<String> networks) {
-        getEntity(id).setNetworks(networks);
+    public void setNetworks(String collectionId, List<String> networks) {
+        getEntity(collectionId).setNetworks(networks);
     }
 
-    public void setSex(String id, List<String> sex) {
-        getEntity(id).setSex(sex);
+    public void setSex(String collectionId, List<String> sex) {
+        getEntity(collectionId).setSex(sex);
     }
 
-    public void setAgeLow(String id, Integer value) {
-        getEntity(id).setAgeLow(value);
+    public void setAgeLow(String collectionId, Integer value) {
+        getEntity(collectionId).setAgeLow(value);
     }
 
-    public void setAgeHigh(String id, Integer value) {
-        getEntity(id).setAgeHigh(value);
+    public void setAgeHigh(String collectionId, Integer value) {
+        getEntity(collectionId).setAgeHigh(value);
     }
 
-    public void setMaterials(String id, List<String> value) {
-        getEntity(id).setMaterials(value);
+    public void setMaterials(String collectionId, List<String> value) {
+        getEntity(collectionId).setMaterials(value);
     }
 
-    public void setStorageTemperatures(String id, List<String> value) {
-        getEntity(id).setStorageTemperatures(value);
+    public void setStorageTemperatures(String collectionId, List<String> value) {
+        getEntity(collectionId).setStorageTemperatures(value);
     }
 
-    public void setDiagnosisAvailable(String id, List<String> value) {
-        getEntity(id).setDiagnosisAvailable(value);
+    public void setDiagnosisAvailable(String collectionId, List<String> value) {
+        getEntity(collectionId).setDiagnosisAvailable(value);
     }
 
     public List<String> getCollectionIds() {
@@ -136,32 +138,62 @@ public class DirectoryCollectionPut extends HashMap {
         return (List<Entity>) get("entities");
     }
 
-    private Entity getEntity(String id) {
+    /**
+     * Retrieves or creates an Entity with the specified collection ID.
+     *
+     * This method searches through the existing entities to find one with a matching
+     * ID. If found, the existing entity is returned; otherwise, a new Entity is created
+     * with the given collection ID and added to the list of entities.
+     *
+     * @param collectionId The unique identifier for the Entity.
+     * @return The Entity with the specified collection ID. If not found, a new Entity
+     *         is created and returned.
+     */
+    private Entity getEntity(String collectionId) {
         Entity entity = null;
 
         for (Entity e: getEntities())
-            if (e.get("id").equals(id)) {
+            if (e.get("id").equals(collectionId)) {
                 entity = e;
                 break;
             }
 
         if (entity == null) {
-            entity = new Entity(id);
+            entity = new Entity(collectionId);
             this.getEntities().add(entity);
         }
 
         return entity;
     }
 
+    /**
+     * Represents an entity with attributes related to a collection.
+     * This class extends HashMap<String, Object> to store key-value pairs.
+     */
     public class Entity extends HashMap<String, Object> {
-        public Entity(String id) {
-            setId(id);
+        /**
+         * Constructs an Entity with the specified collection ID.
+         *
+         * @param collectionId The unique identifier for the Entity.
+         */
+        public Entity(String collectionId) {
+            setId(collectionId);
         }
 
-        public void setId(String id) {
-            put("id", id);
+        /**
+         * Sets the collection ID for the Entity.
+         *
+         * @param collectionId The unique identifier for the Entity.
+         */
+        public void setId(String collectionId) {
+            put("id", collectionId);
         }
 
+        /**
+         * Retrieves the collection ID of the Entity.
+         *
+         * @return The collection ID.
+         */
         public String getId() {
             return (String) get("id");
         }
@@ -288,6 +320,31 @@ public class DirectoryCollectionPut extends HashMap {
                 diagnoses = new ArrayList<String>();
 
             put("diagnosis_available", diagnoses);
+        }
+
+        public List<String> getDiagnosisAvailable() {
+            return (List<String>) get("diagnosis_available");
+        }
+    }
+    
+    /**
+     * Applies corrections to the available diagnoses of each Entity based on a provided map.
+     * The method iterates through the list of entities and updates the available diagnoses
+     * using the provided map of corrections.
+     *
+     * @param correctedDiagnoses A map containing diagnosis corrections, where the keys
+     *                           represent the original diagnoses and the values represent
+     *                           the corrected diagnoses.
+     */
+    public void applyDiagnosisCorrections(Map<String, String> correctedDiagnoses) {
+        for (Entity entity: getEntities()) {
+            List<String> directoryDiagnoses = new ArrayList<String>();
+            for (String diagnosis: entity.getDiagnosisAvailable())
+                if (diagnosis != null
+                    && correctedDiagnoses.containsKey(diagnosis)
+                    && correctedDiagnoses.get(diagnosis) != null)
+                    directoryDiagnoses.add(correctedDiagnoses.get(diagnosis));
+            entity.setDiagnosisAvailable(directoryDiagnoses);
         }
     }
 }

--- a/src/main/java/de/samply/directory_sync/directory/model/DirectoryCollectionPut.java
+++ b/src/main/java/de/samply/directory_sync/directory/model/DirectoryCollectionPut.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +189,15 @@ public class DirectoryCollectionPut extends HashMap {
          */
         public void setId(String collectionId) {
             put("id", collectionId);
+            setTimestamp();
+        }
+
+        public void setTimestamp() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            String formattedDateTime = dateTime.format(formatter);
+
+            put("timestamp", formattedDateTime);
         }
 
         /**
@@ -338,12 +349,11 @@ public class DirectoryCollectionPut extends HashMap {
      */
     public void applyDiagnosisCorrections(Map<String, String> correctedDiagnoses) {
         for (Entity entity: getEntities()) {
-            List<String> directoryDiagnoses = new ArrayList<String>();
-            for (String diagnosis: entity.getDiagnosisAvailable())
-                if (diagnosis != null
-                    && correctedDiagnoses.containsKey(diagnosis)
-                    && correctedDiagnoses.get(diagnosis) != null)
-                    directoryDiagnoses.add(correctedDiagnoses.get(diagnosis));
+            List<String> directoryDiagnoses = entity.getDiagnosisAvailable().stream()
+                .filter(diagnosis -> diagnosis != null && correctedDiagnoses.containsKey(diagnosis) && correctedDiagnoses.get(diagnosis) != null)
+                .map(correctedDiagnoses::get)
+                .distinct()
+                .collect(Collectors.toList());
             entity.setDiagnosisAvailable(directoryDiagnoses);
         }
     }

--- a/src/main/java/de/samply/directory_sync/fhir/FhirReporting.java
+++ b/src/main/java/de/samply/directory_sync/fhir/FhirReporting.java
@@ -279,13 +279,17 @@ public class FhirReporting {
       .flatMap(List::stream)
       .map(s -> fhirApi.extractDiagnosesFromSpecimen(s))
       .flatMap(List::stream)
+      .distinct()
       .collect(Collectors.toList());
 
     // Get diagnoses from Patients
-    List<String> patientDiagnoses = specimensByCollection.values().stream()
+    Either<OperationOutcome, Map<String, List<Patient>>> patientsByCollectionOutcome = fhirApi.fetchPatientsByCollection(specimensByCollection);
+    Map<String, List<Patient>> patientsByCollection = patientsByCollectionOutcome.get();
+    List<String> patientDiagnoses = patientsByCollection.values().stream()
       .flatMap(List::stream)
-      .map(s -> fhirApi.extractConditionCodesFromPatient(fhirApi.extractPatientFromSpecimen(s)))
+      .map(s -> fhirApi.extractConditionCodesFromPatient(s))
       .flatMap(List::stream)
+      .distinct()
       .collect(Collectors.toList());
 
     // Combine diagnoses from specimens and patients, ensuring that there


### PR DESCRIPTION
The previous version of the new Directory sync functionalities were carried out with small test datasets.

When tested with a dataset containing 50K patients, 500K samples and 26K diagnoses, a number of problems became apparent:

1. For some operations, the FHIR store or the Directory use paging, so the code had to be modified.
2. Not all if the diagnosis ICD10 codes are known to the Directory, so a correction mechanism was developed.
3. During long program runs, the Directory login timed out, so this had to be refreshed.